### PR TITLE
NuGetPackageRoot doesn't always have a trailing slash

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AnnotatedReferenceAssemblyDirectory Condition="'$(AnnotatedReferenceAssemblyDirectory)' == ''">$(NuGetPackageRoot)microsoft.netcore.app.ref\$(AnnotatedReferenceAssemblyVersion)\ref\netcoreapp3.0\</AnnotatedReferenceAssemblyDirectory>
+    <AnnotatedReferenceAssemblyDirectory Condition="'$(AnnotatedReferenceAssemblyDirectory)' == ''">$(NuGetPackageRoot)\microsoft.netcore.app.ref\$(AnnotatedReferenceAssemblyVersion)\ref\netcoreapp3.0\</AnnotatedReferenceAssemblyDirectory>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As evidenced by:

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <config>
    <add key="globalPackagesFolder" value="packages" />
  </config>
</configuration>
```

MSBuild Structured Log Viewer:

![image](https://user-images.githubusercontent.com/8040367/65924380-72259a80-e3ba-11e9-84ce-5b0fe61bf5be.png)

![image](https://user-images.githubusercontent.com/8040367/65924401-8ec1d280-e3ba-11e9-978d-6ad2b65717cd.png)



The result is that all reference assemblies go silently unannotated:

```
AnnotateReferenceAssemblies:
Skipping target "AnnotateReferenceAssemblies" because it has no inputs.
```