### PR TITLE
Respect NoWarn in project

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -19,6 +19,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             TargetFrameworkDirectories = null!;
             AnnotatedReferenceAssemblyDirectory = null!;
             OutputPath = null!;
+            NoWarn = null!;
         }
 
         [Required]
@@ -49,14 +50,15 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             set;
         }
 
-        [Output]
-        public ITaskItem[]? GeneratedAssemblies
+        [Required]
+        public string NoWarn
         {
             get;
             set;
         }
 
-        public string? NoWarn
+        [Output]
+        public ITaskItem[]? GeneratedAssemblies
         {
             get;
             set;

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -19,7 +19,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             TargetFrameworkDirectories = null!;
             AnnotatedReferenceAssemblyDirectory = null!;
             OutputPath = null!;
-            NoWarn = null!;
+            DisabledWarnings = null!;
         }
 
         [Required]
@@ -51,7 +51,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
         }
 
         [Required]
-        public string NoWarn
+        public string DisabledWarnings
         {
             get;
             set;
@@ -66,7 +66,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
         public override bool Execute()
         {
-            var log = new SuppressibleLoggingHelper(Log, requiredPrefix: "RA", NoWarn);
+            var log = new SuppressibleLoggingHelper(Log, requiredPrefix: "RA", DisabledWarnings);
 
             string unannotatedReferenceAssembly = TargetFrameworkDirectories.Select(path => Path.Combine(path.ItemSpec, UnannotatedReferenceAssembly + ".dll")).FirstOrDefault(File.Exists);
             string annotatedReferenceAssembly = Path.Combine(AnnotatedReferenceAssemblyDirectory, UnannotatedReferenceAssembly + ".dll");

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -55,8 +55,16 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             set;
         }
 
+        public string[]? NoWarn
+        {
+            get;
+            set;
+        }
+
         public override bool Execute()
         {
+            var log = new SuppressibleLoggingHelper(Log, NoWarn);
+
             string unannotatedReferenceAssembly = TargetFrameworkDirectories.Select(path => Path.Combine(path.ItemSpec, UnannotatedReferenceAssembly + ".dll")).FirstOrDefault(File.Exists);
             string annotatedReferenceAssembly = Path.Combine(AnnotatedReferenceAssemblyDirectory, UnannotatedReferenceAssembly + ".dll");
             bool foundAnnotatedAssembly = File.Exists(annotatedReferenceAssembly);
@@ -80,7 +88,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
             Directory.CreateDirectory(OutputPath);
             string outputAssembly = Path.Combine(OutputPath, Path.GetFileName(unannotatedReferenceAssembly));
-            Program.Main(Log, unannotatedReferenceAssembly, annotatedReferenceAssembly, outputAssembly);
+            Program.Main(log, unannotatedReferenceAssembly, annotatedReferenceAssembly, outputAssembly);
             GeneratedAssemblies = new[] { new TaskItem(outputAssembly) };
 
             return true;

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -3,6 +3,7 @@
 
 namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 {
+    using System;
     using System.IO;
     using System.Linq;
     using Microsoft.Build.Framework;
@@ -55,7 +56,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             set;
         }
 
-        public string[]? NoWarn
+        public string? NoWarn
         {
             get;
             set;

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -64,7 +64,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
         public override bool Execute()
         {
-            var log = new SuppressibleLoggingHelper(Log, NoWarn);
+            var log = new SuppressibleLoggingHelper(Log, requiredPrefix: "RA", NoWarn);
 
             string unannotatedReferenceAssembly = TargetFrameworkDirectories.Select(path => Path.Combine(path.ItemSpec, UnannotatedReferenceAssembly + ".dll")).FirstOrDefault(File.Exists);
             string annotatedReferenceAssembly = Path.Combine(AnnotatedReferenceAssemblyDirectory, UnannotatedReferenceAssembly + ".dll");

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -71,12 +71,12 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             attributesOfInterest.Add(notNullIfNotNullAttribute.FullName, notNullIfNotNullAttribute);
             attributesOfInterest.Add(notNullWhenAttribute.FullName, notNullWhenAttribute);
 
-            AnnotateAssembly(log?.Helper, assemblyDefinition, annotatedAssemblyDefinition, attributesOfInterest);
+            AnnotateAssembly(log, assemblyDefinition, annotatedAssemblyDefinition, attributesOfInterest);
 
             assemblyDefinition.Write(outputAssembly);
         }
 
-        private static void AnnotateAssembly(TaskLoggingHelper? log, AssemblyDefinition assemblyDefinition, AssemblyDefinition annotatedAssemblyDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
+        private static void AnnotateAssembly(SuppressibleLoggingHelper? log, AssemblyDefinition assemblyDefinition, AssemblyDefinition annotatedAssemblyDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
         {
             Annotate(assemblyDefinition, annotatedAssemblyDefinition, attributesOfInterest);
             if (assemblyDefinition.Modules.Count != 1)
@@ -85,7 +85,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             AnnotateModule(log, assemblyDefinition.MainModule, annotatedAssemblyDefinition.MainModule, attributesOfInterest);
         }
 
-        private static void AnnotateModule(TaskLoggingHelper? log, ModuleDefinition moduleDefinition, ModuleDefinition annotatedModuleDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
+        private static void AnnotateModule(SuppressibleLoggingHelper? log, ModuleDefinition moduleDefinition, ModuleDefinition annotatedModuleDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
         {
             Annotate(moduleDefinition, annotatedModuleDefinition, attributesOfInterest);
             foreach (var type in moduleDefinition.GetAllTypes())
@@ -94,7 +94,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             }
         }
 
-        private static void AnnotateType(TaskLoggingHelper? log, TypeDefinition typeDefinition, ModuleDefinition annotatedModuleDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
+        private static void AnnotateType(SuppressibleLoggingHelper? log, TypeDefinition typeDefinition, ModuleDefinition annotatedModuleDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
         {
             if (attributesOfInterest.ContainsKey(typeDefinition.FullName))
                 return;
@@ -138,7 +138,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             }
         }
 
-        private static void AnnotateMethod(TaskLoggingHelper? log, MethodDefinition methodDefinition, TypeDefinition annotatedTypeDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
+        private static void AnnotateMethod(SuppressibleLoggingHelper? log, MethodDefinition methodDefinition, TypeDefinition annotatedTypeDefinition, Dictionary<string, TypeDefinition> attributesOfInterest)
         {
             var annotatedMethodDefinition = FindMatchingMethod(log, methodDefinition, annotatedTypeDefinition);
             if (annotatedMethodDefinition is null)
@@ -217,7 +217,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             }
         }
 
-        private static TypeDefinition? FindMatchingType(TaskLoggingHelper? log, TypeDefinition typeDefinition, ModuleDefinition annotatedModuleDefinition)
+        private static TypeDefinition? FindMatchingType(SuppressibleLoggingHelper? log, TypeDefinition typeDefinition, ModuleDefinition annotatedModuleDefinition)
         {
             if (typeDefinition.IsNested)
             {
@@ -256,7 +256,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             return annotatedTypeDefinition;
         }
 
-        private static MethodDefinition FindMatchingMethod(TaskLoggingHelper? log, MethodDefinition methodDefinition, TypeDefinition annotatedTypeDefinition)
+        private static MethodDefinition FindMatchingMethod(SuppressibleLoggingHelper? log, MethodDefinition methodDefinition, TypeDefinition annotatedTypeDefinition)
         {
             try
             {

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -14,7 +14,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
     internal class Program
     {
-        internal static void Main(TaskLoggingHelper? log, string referenceAssembly, string annotatedReferenceAssembly, string outputAssembly)
+        internal static void Main(SuppressibleLoggingHelper? log, string referenceAssembly, string annotatedReferenceAssembly, string outputAssembly)
         {
             var assemblyResolver = new DefaultAssemblyResolver();
             assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(referenceAssembly));
@@ -24,7 +24,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             {
                 if (!module.Attributes.HasFlag(ModuleAttributes.ILOnly))
                 {
-                    log?.LogWarning(subcategory: null, "RA1000", helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, "Skipping mixed-mode implementation assembly '{0}'", assemblyDefinition.Name);
+                    log?.LogWarning("RA1000", "Skipping mixed-mode implementation assembly '{0}'", assemblyDefinition.Name);
                     return;
                 }
             }
@@ -71,7 +71,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             attributesOfInterest.Add(notNullIfNotNullAttribute.FullName, notNullIfNotNullAttribute);
             attributesOfInterest.Add(notNullWhenAttribute.FullName, notNullWhenAttribute);
 
-            AnnotateAssembly(log, assemblyDefinition, annotatedAssemblyDefinition, attributesOfInterest);
+            AnnotateAssembly(log?.Helper, assemblyDefinition, annotatedAssemblyDefinition, attributesOfInterest);
 
             assemblyDefinition.Write(outputAssembly);
         }

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -26,13 +26,13 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             _disabledWarnings = disabledWarnings
                 .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(item => item.Trim())
-                .Where(item => item.StartsWith(requiredPrefix, StringComparison.OrdinalIgnoreCase))
-                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+                .Where(item => item.StartsWith(requiredPrefix, StringComparison.Ordinal))
+                .ToImmutableHashSet(StringComparer.Ordinal);
         }
 
         public void LogWarning(string warningCode, string message, params object?[] messageArgs)
         {
-            if (!warningCode.StartsWith(_requiredPrefix, StringComparison.OrdinalIgnoreCase))
+            if (!warningCode.StartsWith(_requiredPrefix, StringComparison.Ordinal))
                 throw new ArgumentException($"Warning code '{warningCode}' does not begin with the required prefix '{_requiredPrefix}'.", nameof(warningCode));
 
             if (_disabledWarnings.Contains(warningCode))

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -4,18 +4,23 @@
 namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq;
     using Microsoft.Build.Utilities;
 
     internal readonly struct SuppressibleLoggingHelper
     {
         private readonly ImmutableHashSet<string> _noWarn;
 
-        public SuppressibleLoggingHelper(TaskLoggingHelper helper, IEnumerable<string>? noWarn)
+        public SuppressibleLoggingHelper(TaskLoggingHelper helper, string? noWarn)
         {
             Helper = helper;
-            _noWarn = noWarn?.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase) ?? ImmutableHashSet<string>.Empty;
+
+            _noWarn = noWarn
+                ?.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(item => item.Trim())
+                .Where(item => item.Length != 0)
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase) ?? ImmutableHashSet<string>.Empty;
         }
 
         public TaskLoggingHelper Helper { get; }

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -10,17 +10,18 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
     internal readonly struct SuppressibleLoggingHelper
     {
+        private readonly TaskLoggingHelper _helper;
         private readonly ImmutableHashSet<string> _disabledWarnings;
         private readonly string _requiredPrefix;
 
         public SuppressibleLoggingHelper(TaskLoggingHelper helper, string requiredPrefix, string disabledWarnings)
         {
+            _helper = helper;
+
             if (string.IsNullOrWhiteSpace(requiredPrefix))
                 throw new ArgumentException("A required warning prefix must be supplied.", nameof(requiredPrefix));
 
             _requiredPrefix = requiredPrefix;
-
-            Helper = helper;
 
             _disabledWarnings = disabledWarnings
                 .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
@@ -28,8 +29,6 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
                 .Where(item => item.StartsWith(requiredPrefix, StringComparison.OrdinalIgnoreCase))
                 .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
         }
-
-        public TaskLoggingHelper Helper { get; }
 
         public void LogWarning(string warningCode, string message, params object?[] messageArgs)
         {
@@ -39,7 +38,12 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             if (_disabledWarnings.Contains(warningCode))
                 return;
 
-            Helper.LogWarning(subcategory: null, warningCode, helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message, messageArgs);
+            _helper.LogWarning(subcategory: null, warningCode, helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message, messageArgs);
+        }
+
+        public void LogMessage(string message, params object?[] messageArgs)
+        {
+            _helper.LogMessage(message, messageArgs);
         }
     }
 }

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -10,10 +10,10 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
     internal readonly struct SuppressibleLoggingHelper
     {
-        private readonly ImmutableHashSet<string> _noWarn;
+        private readonly ImmutableHashSet<string> _disabledWarnings;
         private readonly string _requiredPrefix;
 
-        public SuppressibleLoggingHelper(TaskLoggingHelper helper, string requiredPrefix, string noWarn)
+        public SuppressibleLoggingHelper(TaskLoggingHelper helper, string requiredPrefix, string disabledWarnings)
         {
             if (string.IsNullOrWhiteSpace(requiredPrefix))
                 throw new ArgumentException("A required warning prefix must be supplied.", nameof(requiredPrefix));
@@ -22,7 +22,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
             Helper = helper;
 
-            _noWarn = noWarn
+            _disabledWarnings = disabledWarnings
                 .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(item => item.Trim())
                 .Where(item => item.StartsWith(requiredPrefix, StringComparison.OrdinalIgnoreCase))
@@ -36,7 +36,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             if (!warningCode.StartsWith(_requiredPrefix, StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentException($"Warning code '{warningCode}' does not begin with the required prefix '{_requiredPrefix}'.", nameof(warningCode));
 
-            if (_noWarn.Contains(warningCode))
+            if (_disabledWarnings.Contains(warningCode))
                 return;
 
             Helper.LogWarning(subcategory: null, warningCode, helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message, messageArgs);

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.Build.Utilities;
+
+    internal readonly struct SuppressibleLoggingHelper
+    {
+        private readonly ImmutableHashSet<string> _noWarn;
+
+        public SuppressibleLoggingHelper(TaskLoggingHelper helper, IEnumerable<string>? noWarn)
+        {
+            Helper = helper;
+            _noWarn = noWarn?.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase) ?? ImmutableHashSet<string>.Empty;
+        }
+
+        public TaskLoggingHelper Helper { get; }
+
+        public void LogWarning(string warningCode, string message, params object?[] messageArgs)
+        {
+            if (_noWarn.Contains(warningCode))
+                return;
+
+            Helper.LogWarning(subcategory: null, warningCode, helpKeyword: null, file: null, lineNumber: 0, columnNumber: 0, endLineNumber: 0, endColumnNumber: 0, message, messageArgs);
+        }
+    }
+}

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/SuppressibleLoggingHelper.cs
@@ -13,7 +13,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
         private readonly ImmutableHashSet<string> _noWarn;
         private readonly string _requiredPrefix;
 
-        public SuppressibleLoggingHelper(TaskLoggingHelper helper, string requiredPrefix, string? noWarn)
+        public SuppressibleLoggingHelper(TaskLoggingHelper helper, string requiredPrefix, string noWarn)
         {
             if (string.IsNullOrWhiteSpace(requiredPrefix))
                 throw new ArgumentException("A required warning prefix must be supplied.", nameof(requiredPrefix));
@@ -23,10 +23,10 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             Helper = helper;
 
             _noWarn = noWarn
-                ?.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(item => item.Trim())
                 .Where(item => item.StartsWith(requiredPrefix, StringComparison.OrdinalIgnoreCase))
-                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase) ?? ImmutableHashSet<string>.Empty;
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         public TaskLoggingHelper Helper { get; }

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -61,7 +61,8 @@
       UnannotatedReferenceAssembly="%(UnannotatedReferenceAssembly.Identity)"
       TargetFrameworkDirectories="@(AvailableUnannotatedReferenceAssemblyDirectory)"
       AnnotatedReferenceAssemblyDirectory="$(AnnotatedReferenceAssemblyDirectory)"
-      OutputPath="$(AnnotatedReferenceAssemblyOutputPath)">
+      OutputPath="$(AnnotatedReferenceAssemblyOutputPath)"
+      NoWarn="$(NoWarn)">
       <Output ItemName="GeneratedReferenceAssemblies" TaskParameter="GeneratedAssemblies" />
     </AnnotatorBuildTask>
 

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -62,7 +62,7 @@
       TargetFrameworkDirectories="@(AvailableUnannotatedReferenceAssemblyDirectory)"
       AnnotatedReferenceAssemblyDirectory="$(AnnotatedReferenceAssemblyDirectory)"
       OutputPath="$(AnnotatedReferenceAssemblyOutputPath)"
-      NoWarn="$(NoWarn)">
+      DisabledWarnings="$(NoWarn)">
       <Output ItemName="GeneratedReferenceAssemblies" TaskParameter="GeneratedAssemblies" />
     </AnnotatorBuildTask>
 


### PR DESCRIPTION
Closes #31. Confirmed that the warning disappeared after updating to the locally build package using a net35 project with the System.Data warning.

I tested against this weird NoWarn property to verify that I had declared the task property in a valid way. `string[]` appears to trigger automatic splitting and trimming.

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net35</TargetFramework>
    <LangVersion>latest</LangVersion>
    <Nullable>enable</Nullable>
    <AnnotatedReferenceAssemblyVersion>3.0.0</AnnotatedReferenceAssemblyVersion>
    <NoWarn>; ; RA1000 ;; </NoWarn>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.*" PrivateAssets="all" />
    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
  </ItemGroup>

</Project>
```