### PR TITLE
Add the recommended URLs to the package metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,6 +69,10 @@
     <Copyright>Copyright © Tunnel Vision Laboratories, LLC 2019</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>sharwell</Authors>
+    <PackageProjectUrl>https://github.com/tunnelvisionlabs/ReferenceAssemblyAnnotator</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/tunnelvisionlabs/ReferenceAssemblyAnnotator</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
 
     <IncludeSymbols>true</IncludeSymbols>
     <IncludeSource>true</IncludeSource>

--- a/ReferenceAssemblyAnnotator.sln
+++ b/ReferenceAssemblyAnnotator.sln
@@ -7,6 +7,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CecilBasedAnnotator", "Ceci
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TunnelVisionLabs.ReferenceAssemblyAnnotator", "TunnelVisionLabs.ReferenceAssemblyAnnotator\TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj", "{8133EC1F-B531-4094-A76E-F155E4117D30}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{51FA6781-3E2C-4F33-9A73-D789899E93B6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		global.json = global.json
+		stylecop.json = stylecop.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Earlier today I noticed there were no links from the NuGet gallery page back to the repository. I wanted to use the usual project or repository links as a quick way to get to the readme.