### PR TITLE
Use deferred reading mode so that AssemblyResolutionException is handled per type

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -18,7 +18,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
         {
             var assemblyResolver = new DefaultAssemblyResolver();
             assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(referenceAssembly));
-            using var assemblyDefinition = AssemblyDefinition.ReadAssembly(referenceAssembly, new ReaderParameters(ReadingMode.Immediate) { AssemblyResolver = assemblyResolver });
+            using var assemblyDefinition = AssemblyDefinition.ReadAssembly(referenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = assemblyResolver });
 
             foreach (var module in assemblyDefinition.Modules)
             {
@@ -31,7 +31,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
             var annotatedAssemblyResolver = new DefaultAssemblyResolver();
             annotatedAssemblyResolver.AddSearchDirectory(Path.GetDirectoryName(annotatedReferenceAssembly));
-            using var annotatedAssemblyDefinition = AssemblyDefinition.ReadAssembly(annotatedReferenceAssembly, new ReaderParameters(ReadingMode.Immediate) { AssemblyResolver = annotatedAssemblyResolver });
+            using var annotatedAssemblyDefinition = AssemblyDefinition.ReadAssembly(annotatedReferenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = annotatedAssemblyResolver });
 
             var wellKnownTypes = new WellKnownTypes(assemblyDefinition, DefineReferenceAssemblyAttribute);
 


### PR DESCRIPTION
Fixes #37. I'm not sure if there's another place we should be catching `AssemblyResolutionException`, but if so, Shouldly's CI avoided it and built successfully.

Before: https://ci.appveyor.com/project/shouldly/shouldly/builds/28135259/job/cjgxr82wq8ohegu2#L767

After (using `[1.0.0-alpha.80.g0c15c15c1b]` from the AppVeyor feed): https://ci.appveyor.com/project/shouldly/shouldly/builds/28163994/job/mw9jc5olkhocfk25