### PR TITLE
Suppress dependencies when packing

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj
@@ -8,6 +8,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <BuildOutputTargetFolder>tools</BuildOutputTargetFolder>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <PackageId>TunnelVisionLabs.ReferenceAssemblyAnnotator.NewIdRequiredDueToNuGetBug</PackageId>
   </PropertyGroup>
 


### PR DESCRIPTION
This change removes the `<dependencies>` node from the final NuGet package altogether.