### PR TITLE
Project updates

### DIFF
--- a/CecilBasedAnnotator/CecilBasedAnnotator.csproj
+++ b/CecilBasedAnnotator/CecilBasedAnnotator.csproj
@@ -10,12 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\TunnelVisionLabs.ReferenceAssemblyAnnotator\TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.53" PrivateAssets="all" />
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.90" PrivateAssets="all" />
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,9 +29,9 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <!-- Use the 16.3 compiler -->
+  <!-- Use the 16.4 compiler -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="3.3.1-beta3-final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.4.0-beta2-final" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Enable nullable reference types -->

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" PrivateAssets="all" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Now that dependencies are excluded from the NuGet package with the 'SuppressDependenciesWhenPacking' option, we can keep them as normal dependencies for ProjectReference purposes.
* Update TunnelVisionLabs.ReferenceAssemblyAnnotator
* Update Microsoft.Net.Compilers