### PR TITLE
Use stripped-down resolver for perf (no GAC, deferred reading mode)

### DIFF
--- a/CecilBasedAnnotator/Program.cs
+++ b/CecilBasedAnnotator/Program.cs
@@ -3,11 +3,18 @@
 
 namespace CecilBasedAnnotator
 {
+    using System.Collections.Immutable;
+
     internal class Program
     {
         private static void Main(string[] args)
         {
-            TunnelVisionLabs.ReferenceAssemblyAnnotator.Program.Main(log: null, args[0], args[1], args[2]);
+            TunnelVisionLabs.ReferenceAssemblyAnnotator.Program.Main(
+                log: null,
+                referenceAssembly: args[0],
+                targetFrameworkDirectories: args[1].Split(';').ToImmutableArray(),
+                annotatedReferenceAssembly: args[2],
+                outputAssembly: args[3]);
         }
     }
 }

--- a/CecilBasedAnnotator/Properties/launchSettings.json
+++ b/CecilBasedAnnotator/Properties/launchSettings.json
@@ -1,12 +1,12 @@
 {
   "profiles": {
-    "mscorlib": {
+    "Microsoft.Win32.Primitives (netstandard1.6)": {
       "commandName": "Project",
-      "commandLineArgs": "\"$(NuGetPackageRoot)\\microsoft.netframework.referenceassemblies.net45\\1.0.0-preview.2\\build\\.NETFramework\\v4.5\\mscorlib.dll\" \"$(NuGetPackageRoot)\\microsoft.netcore.app.ref\\3.0.0-preview8-28405-07\\ref\\netcoreapp3.0\\mscorlib.dll\" mscorlib2.dll"
+      "commandLineArgs": "\"$(NuGetPackageRoot)\\microsoft.win32.primitives\\4.3.0\\ref\\netstandard1.3\\Microsoft.Win32.Primitives.dll\" \"$(NuGetPackageRoot)\\microsoft.win32.primitives\\4.3.0\\ref\\netstandard1.3\\;$(NuGetPackageRoot)\\system.runtime\\4.3.0\\ref\\netstandard1.5\\\\\" \"$(NuGetPackageRoot)\\microsoft.netcore.app.ref\\3.0.0\\ref\\netcoreapp3.0\\Microsoft.Win32.Primitives.dll\" Microsoft.Win32.Primitives.dll"
     },
-    "System": {
+    "System.ComponentModel.DataAnnotations (netcoreapp2.0)": {
       "commandName": "Project",
-      "commandLineArgs": "\"$(NuGetPackageRoot)\\microsoft.netframework.referenceassemblies.net45\\1.0.0-preview.2\\build\\.NETFramework\\v4.5\\System.dll\" \"$(NuGetPackageRoot)\\microsoft.netcore.app.ref\\3.0.0-preview8-28405-07\\ref\\netcoreapp3.0\\System.dll\" System2.dll"
+      "commandLineArgs": "\"$(NuGetPackageRoot)\\microsoft.netcore.app\\2.0.0\\ref\\netcoreapp2.0\\System.ComponentModel.DataAnnotations.dll\" \"$(NuGetPackageRoot)\\microsoft.netcore.app\\2.0.0\\ref\\netcoreapp2.0\\\\\" \"$(NuGetPackageRoot)\\microsoft.netcore.app.ref\\3.0.0\\ref\\netcoreapp3.0\\System.ComponentModel.DataAnnotations.dll\" System.ComponentModel.DataAnnotations.dll"
     }
   }
 }

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -4,6 +4,7 @@
 namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 {
     using System;
+    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using Microsoft.Build.Framework;
@@ -96,7 +97,14 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
             Directory.CreateDirectory(OutputPath);
             string outputAssembly = Path.Combine(OutputPath, Path.GetFileName(unannotatedReferenceAssembly));
-            Program.Main(log, unannotatedReferenceAssembly, annotatedReferenceAssembly, outputAssembly);
+
+            Program.Main(
+                log,
+                unannotatedReferenceAssembly,
+                TargetFrameworkDirectories.Select(item => item.ItemSpec).ToImmutableArray(),
+                annotatedReferenceAssembly,
+                outputAssembly);
+
             GeneratedAssemblies = new[] { new TaskItem(outputAssembly) };
 
             string sourceDocumentation = Path.ChangeExtension(unannotatedReferenceAssembly, ".xml");

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AssemblyResolver.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AssemblyResolver.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Mono.Cecil;
+
+    internal sealed class AssemblyResolver : IAssemblyResolver
+    {
+        private static readonly ReaderParameters DefaultReaderParameters = new ReaderParameters(ReadingMode.Deferred);
+
+        private readonly string _searchDirectory;
+        private readonly Dictionary<string, AssemblyDefinition?> _assembliesByFileName = new Dictionary<string, AssemblyDefinition?>();
+
+        public AssemblyResolver(string searchDirectory)
+        {
+            _searchDirectory = searchDirectory;
+        }
+
+        public AssemblyDefinition? Resolve(AssemblyNameReference name)
+        {
+            return Resolve(name, DefaultReaderParameters);
+        }
+
+        public AssemblyDefinition? Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (!_assembliesByFileName.TryGetValue(name.Name, out var assembly))
+            {
+                var stream = OpenReadIfExists(Path.Combine(_searchDirectory, name.Name + ".dll"));
+
+                assembly = stream is null ? null : AssemblyDefinition.ReadAssembly(stream, parameters);
+
+                _assembliesByFileName.Add(name.Name, assembly);
+            }
+
+            return assembly is object && Matches(assembly.Name, name) ? assembly : null;
+        }
+
+        private static FileStream? OpenReadIfExists(string path)
+        {
+            try
+            {
+                return File.OpenRead(path);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// The point of this method is to be a high-performance sanity check, not to reproduce .NET assembly loading
+        /// behavior.
+        /// </summary>
+        private static bool Matches(AssemblyNameDefinition definition, AssemblyNameReference reference)
+        {
+            return definition.Name == reference.Name
+                && definition.Version == reference.Version;
+        }
+
+        public void Dispose()
+        {
+            foreach (var loadedAssembly in _assembliesByFileName.Values)
+            {
+                loadedAssembly?.Dispose();
+            }
+
+            _assembliesByFileName.Clear();
+        }
+    }
+}

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -15,8 +15,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
     {
         internal static void Main(SuppressibleLoggingHelper? log, string referenceAssembly, string annotatedReferenceAssembly, string outputAssembly)
         {
-            var assemblyResolver = new DefaultAssemblyResolver();
-            assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(referenceAssembly));
+            using var assemblyResolver = new AssemblyResolver(Path.GetDirectoryName(Path.GetFullPath(referenceAssembly))!);
             using var assemblyDefinition = AssemblyDefinition.ReadAssembly(referenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = assemblyResolver });
 
             foreach (var module in assemblyDefinition.Modules)
@@ -28,8 +27,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
                 }
             }
 
-            var annotatedAssemblyResolver = new DefaultAssemblyResolver();
-            annotatedAssemblyResolver.AddSearchDirectory(Path.GetDirectoryName(annotatedReferenceAssembly));
+            using var annotatedAssemblyResolver = new AssemblyResolver(Path.GetDirectoryName(Path.GetFullPath(annotatedReferenceAssembly))!);
             using var annotatedAssemblyDefinition = AssemblyDefinition.ReadAssembly(annotatedReferenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = annotatedAssemblyResolver });
 
             var wellKnownTypes = new WellKnownTypes(assemblyDefinition);

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -25,6 +25,12 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
                     log?.LogWarning("RA1000", "Skipping mixed-mode implementation assembly '{0}'", assemblyDefinition.Name);
                     return;
                 }
+
+                if (module.TypeSystem.Object.Resolve() is null)
+                {
+                    log?.LogWarning("RA1001", "Cannot resolve core library for assembly '{0}', skipping", assemblyDefinition.Name);
+                    return;
+                }
             }
 
             using var annotatedAssemblyResolver = new AssemblyResolver(Path.GetDirectoryName(Path.GetFullPath(annotatedReferenceAssembly))!);

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -5,6 +5,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
@@ -13,9 +14,9 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
     internal class Program
     {
-        internal static void Main(SuppressibleLoggingHelper? log, string referenceAssembly, string annotatedReferenceAssembly, string outputAssembly)
+        internal static void Main(SuppressibleLoggingHelper? log, string referenceAssembly, ImmutableArray<string> targetFrameworkDirectories, string annotatedReferenceAssembly, string outputAssembly)
         {
-            using var assemblyResolver = new AssemblyResolver(Path.GetDirectoryName(Path.GetFullPath(referenceAssembly))!);
+            using var assemblyResolver = new AssemblyResolver(targetFrameworkDirectories);
             using var assemblyDefinition = AssemblyDefinition.ReadAssembly(referenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = assemblyResolver });
 
             foreach (var module in assemblyDefinition.Modules)
@@ -33,7 +34,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
                 }
             }
 
-            using var annotatedAssemblyResolver = new AssemblyResolver(Path.GetDirectoryName(Path.GetFullPath(annotatedReferenceAssembly))!);
+            using var annotatedAssemblyResolver = new AssemblyResolver(ImmutableArray.Create(Path.GetDirectoryName(Path.GetFullPath(annotatedReferenceAssembly))!));
             using var annotatedAssemblyDefinition = AssemblyDefinition.ReadAssembly(annotatedReferenceAssembly, new ReaderParameters(ReadingMode.Deferred) { AssemblyResolver = annotatedAssemblyResolver });
 
             var wellKnownTypes = new WellKnownTypes(assemblyDefinition);


### PR DESCRIPTION
Contributes to #53.

Total assembly resolve time is 964 ms (version 1.0.0-alpha.99.g7d2f4a388d):

![image](https://user-images.githubusercontent.com/8040367/68521482-7a051400-026f-11ea-8490-39a655c8a199.png)

Where alpha.97 took 8328 ms:

![image](https://user-images.githubusercontent.com/8040367/68521506-afa9fd00-026f-11ea-91e9-f7071dcf8064.png)

Total time is now 17.4 seconds:

![image](https://user-images.githubusercontent.com/8040367/68521377-7ae97600-026e-11ea-97a6-ef6b043a53ed.png)
