### PR TITLE
Permit DisabledWarnings to be empty

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -50,7 +50,6 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             set;
         }
 
-        [Required]
         public string DisabledWarnings
         {
             get;


### PR DESCRIPTION
Fixes #55. The other string properties don't sound optional.