### PR TITLE
Fix assembly resolution for more target frameworks

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/Program.cs
@@ -171,10 +171,14 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
         private static void Annotate(ModuleDefinition module, ICustomAttributeProvider provider, ICustomAttributeProvider annotatedProvider, Dictionary<string, TypeDefinition> attributesOfInterest)
         {
-            // Start by removing any prior attributes that need to be filtered out
+            // Start by removing excluded attributes as well as attributes of interest to allow, say, rewriting
+            // netcoreapp3.1 to use .NET 5 reference annotations.
             for (int i = 0; i < provider.CustomAttributes.Count; i++)
             {
-                if (IsExcludedAnnotation(provider, annotatedProvider, provider.CustomAttributes[i]))
+                var customAttribute = provider.CustomAttributes[i];
+
+                if (attributesOfInterest.ContainsKey(customAttribute.AttributeType.FullName)
+                    || IsExcludedAnnotation(provider, annotatedProvider, customAttribute))
                 {
                     provider.CustomAttributes.RemoveAt(i);
                     i--;

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -77,9 +77,9 @@
   </Target>
 
   <Target Name="RestoreTargetFrameworkDirectory"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
       <_NetStandardReferences Include="@(Reference)"
                               Condition="
@@ -130,7 +130,7 @@
       <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NetStandardNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <_NuGetPackageFoldersItems Include="$(NuGetPackageFolders)" />
       <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
@@ -175,7 +175,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
@@ -226,7 +226,7 @@
                                     IsNetStandard="True" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.NuGetPackageId)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
@@ -236,7 +236,7 @@
   </Target>
 
   <Target Name="UpdateNetStandardAssemblies"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'"
           DependsOnTargets="AnnotateReferenceAssemblies">
     <ItemGroup>
       <Reference Remove="%(UnannotatedReferenceAssembly.OriginalReference)"

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
+    <!-- This is the target that first produces the Reference items needed by each of these targets. -->
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveLockFileReferences</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveLockFileReferences</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
@@ -36,6 +37,7 @@
   <PropertyGroup Condition="
                  ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')))
                  OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1')))">
+    <!-- This is the target that first produces the Reference items needed by each of these targets. -->
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveTargetingPackAssets</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -79,7 +79,7 @@
   <Target Name="RestoreTargetFrameworkDirectory"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
       <_NetStandardReferences Include="@(Reference)"
                               Condition="
@@ -130,7 +130,7 @@
       <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NetStandardNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <_NuGetPackageFoldersItems Include="$(NuGetPackageFolders)" />
       <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
@@ -175,7 +175,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
@@ -226,7 +226,7 @@
                                     IsNetStandard="True" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.NuGetPackageId)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -24,7 +24,7 @@
     <ResolveAssemblyReferencesDependsOn>
       $(ResolveAssemblyReferencesDependsOn);
       AnnotateReferenceAssemblies;
-      UpdateNetStandardAssemblies
+      UpdateReferences
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
@@ -251,16 +251,14 @@
                                         OR '%(Reference.NuGetPackageId)' == 'System.Threading.Timer'
                                         OR '%(Reference.NuGetPackageId)' == 'System.Xml.ReaderWriter'
                                         OR '%(Reference.NuGetPackageId)' == 'System.Xml.XDocument')"
-                                    OriginalReference="%(Reference.Identity)"
-                                    IsNetStandard="True" />
+                                    OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2.0 -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.NuGetPackageId)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
-                                    OriginalReference="%(Reference.Identity)"
-                                    IsNetStandard="True" />
+                                    OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
@@ -276,14 +274,14 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="UpdateNetStandardAssemblies"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'"
+  <Target Name="UpdateReferences"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           DependsOnTargets="AnnotateReferenceAssemblies">
     <ItemGroup>
       <Reference Remove="%(UnannotatedReferenceAssembly.OriginalReference)"
-                 Condition="'%(UnannotatedReferenceAssembly.IsNetStandard)' == 'True' AND Exists('%(UnannotatedReferenceAssembly.OutputAssembly)')" />
+                 Condition="Exists('%(UnannotatedReferenceAssembly.OutputAssembly)')" />
       <Reference Include="@(UnannotatedReferenceAssembly->'%(OutputAssembly)')"
-                 Condition="'%(UnannotatedReferenceAssembly.IsNetStandard)' == 'True' AND Exists('%(UnannotatedReferenceAssembly.OutputAssembly)')"
+                 Condition="Exists('%(UnannotatedReferenceAssembly.OutputAssembly)')"
                  HintPath="" />
     </ItemGroup>
   </Target>

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -159,7 +159,12 @@
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+      <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(ResolvedCompileFileDefinitionsToAdd.Identity)'))" />
+      <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
       <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
@@ -267,7 +272,13 @@
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+      <UnannotatedReferenceAssembly Include="@(ResolvedCompileFileDefinitionsToAdd->'%(FileName)')"
+                                    Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(ResolvedCompileFileDefinitionsToAdd.FileName)%(ResolvedCompileFileDefinitionsToAdd.Extension)')"
+                                    OriginalReference="%(ResolvedCompileFileDefinitionsToAdd.Identity)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="('%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App') AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -4,7 +4,12 @@
   <UsingTask TaskName="TunnelVisionLabs.ReferenceAssemblyAnnotator.AnnotatorBuildTask" AssemblyFile="$(ReferenceAssemblyAnnotatorBuildTaskPath)TunnelVisionLabs.ReferenceAssemblyAnnotator.dll" />
 
   <PropertyGroup>
-    <GenerateNullableAttributes Condition="'$(GenerateNullableAttributes)' == ''">true</GenerateNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0'">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(_FrameworkIncludesNullableAttributes)' == ''">false</_FrameworkIncludesNullableAttributes>
+
+    <GenerateNullableAttributes Condition="'$(GenerateNullableAttributes)' == '' AND '$(_FrameworkIncludesNullableAttributes)' != 'true'">true</GenerateNullableAttributes>
+
     <NullableAttributesPath Condition="'$(NullableAttributesPath)' == ''">$(MSBuildThisFileDirectory)NullableAttributes$(DefaultLanguageSourceExtension)</NullableAttributesPath>
   </PropertyGroup>
 

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -23,6 +23,16 @@
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '3.0'">
+    <RestoreTargetFrameworkDirectoryDependsOn>ResolveLockFileReferences</RestoreTargetFrameworkDirectoryDependsOn>
+    <AddStandardAssembliesForAnnotationDependsOn>ResolveLockFileReferences</AddStandardAssembliesForAnnotationDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0'">
+    <RestoreTargetFrameworkDirectoryDependsOn>ResolveTargetingPackAssets</RestoreTargetFrameworkDirectoryDependsOn>
+    <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
+  </PropertyGroup>
+
   <PropertyGroup>
     <AnnotatedReferenceAssemblyDirectory Condition="'$(AnnotatedReferenceAssemblyDirectory)' == ''">$(NuGetPackageRoot)\microsoft.netcore.app.ref\$(AnnotatedReferenceAssemblyVersion)\ref\netcoreapp3.0\</AnnotatedReferenceAssemblyDirectory>
   </PropertyGroup>
@@ -78,7 +88,7 @@
 
   <Target Name="RestoreTargetFrameworkDirectory"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
-          DependsOnTargets="ResolveTargetingPackAssets"
+          DependsOnTargets="$(RestoreTargetFrameworkDirectoryDependsOn)"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
@@ -138,7 +148,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-      <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App'" />
+      <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
@@ -167,7 +177,7 @@
 
   <!-- Automatically annotate .NET Standard assemblies -->
   <Target Name="AddStandardAssembliesForAnnotation"
-          DependsOnTargets="ResolveTargetingPackAssets"
+          DependsOnTargets="$(AddStandardAssembliesForAnnotationDependsOn)"
           BeforeTargets="ResolveOutputReferenceAssemblies">
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
       <UnannotatedReferenceAssembly Include="%(Reference.Identity)"
@@ -244,7 +254,7 @@
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
-                                    Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
+                                    Condition="('%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App') AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
   </Target>

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -4,8 +4,8 @@
   <UsingTask TaskName="TunnelVisionLabs.ReferenceAssemblyAnnotator.AnnotatorBuildTask" AssemblyFile="$(ReferenceAssemblyAnnotatorBuildTaskPath)TunnelVisionLabs.ReferenceAssemblyAnnotator.dll" />
 
   <PropertyGroup>
-    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">true</_FrameworkIncludesNullableAttributes>
-    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0'">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">true</_FrameworkIncludesNullableAttributes>
     <_FrameworkIncludesNullableAttributes Condition="'$(_FrameworkIncludesNullableAttributes)' == ''">false</_FrameworkIncludesNullableAttributes>
 
     <GenerateNullableAttributes Condition="'$(GenerateNullableAttributes)' == '' AND '$(_FrameworkIncludesNullableAttributes)' != 'true'">true</GenerateNullableAttributes>
@@ -28,15 +28,15 @@
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '3.0'">
     <!-- This is the target that first produces the Reference items needed by each of these targets. -->
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveLockFileReferences</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveLockFileReferences</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition="
-                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')))
-                 OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1')))">
+                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0')
+                 OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1')">
     <!-- This is the target that first produces the Reference items needed by each of these targets. -->
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveTargetingPackAssets</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
@@ -99,7 +99,7 @@
           Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           DependsOnTargets="$(RestoreTargetFrameworkDirectoryDependsOn)"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <_TargetFrameworkReferences Include="@(Reference)"
                                   Condition="
                                 '%(NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -155,18 +155,18 @@
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
       <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(ResolvedCompileFileDefinitionsToAdd.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
       <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
@@ -212,7 +212,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
                                       AND ('%(Reference.NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -268,19 +268,19 @@
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <UnannotatedReferenceAssembly Include="@(ResolvedCompileFileDefinitionsToAdd->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(ResolvedCompileFileDefinitionsToAdd.FileName)%(ResolvedCompileFileDefinitionsToAdd.Extension)')"
                                     OriginalReference="%(ResolvedCompileFileDefinitionsToAdd.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.0'))">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="('%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App') AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -77,12 +77,13 @@
   </Target>
 
   <Target Name="RestoreTargetFrameworkDirectory"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
+          DependsOnTargets="ResolveTargetingPackAssets"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
-      <_NetStandardReferences Include="@(Reference)"
-                              Condition="
+      <_TargetFrameworkReferences Include="@(Reference)"
+                                  Condition="
                                 '%(NuGetPackageId)' == 'Microsoft.Win32.Primitives'
                                 OR '%(NuGetPackageId)' == 'XXXSystem.AppContext'
                                 OR '%(NuGetPackageId)' == 'System.Collections'
@@ -126,18 +127,24 @@
                                 OR '%(NuGetPackageId)' == 'System.Threading.Timer'
                                 OR '%(NuGetPackageId)' == 'System.Xml.ReaderWriter'
                                 OR '%(NuGetPackageId)' == 'System.Xml.XDocument'" />
-      <_NetStandardNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_NetStandardReferences.Identity)'))" />
-      <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NetStandardNuGetPackageFoldersNoSlash.Identity)'))" />
+      <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
+      <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <_NuGetPackageFoldersItems Include="$(NuGetPackageFolders)" />
-      <_NetStandardNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
+      <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+      <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App'" />
+      <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
+      <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
     <PropertyGroup>
-      <TargetFrameworkDirectory>@(_NetStandardNuGetPackageFolders)</TargetFrameworkDirectory>
+      <TargetFrameworkDirectory>@(_TargetFrameworkNuGetPackageFolders)</TargetFrameworkDirectory>
     </PropertyGroup>
   </Target>
 
@@ -160,6 +167,7 @@
 
   <!-- Automatically annotate .NET Standard assemblies -->
   <Target Name="AddStandardAssembliesForAnnotation"
+          DependsOnTargets="ResolveTargetingPackAssets"
           BeforeTargets="ResolveOutputReferenceAssemblies">
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
       <UnannotatedReferenceAssembly Include="%(Reference.Identity)"
@@ -175,7 +183,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' == ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
       <!-- .NET Standard 1.x -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
@@ -226,12 +234,18 @@
                                     IsNetStandard="True" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(NETStandardLibraryPackageVersion)' != ''">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
       <!-- .NET Standard 2+ -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.NuGetPackageId)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)"
                                     IsNetStandard="True" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+      <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
+                                    Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
+                                    OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
   </Target>
 

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -4,8 +4,8 @@
   <UsingTask TaskName="TunnelVisionLabs.ReferenceAssemblyAnnotator.AnnotatorBuildTask" AssemblyFile="$(ReferenceAssemblyAnnotatorBuildTaskPath)TunnelVisionLabs.ReferenceAssemblyAnnotator.dll" />
 
   <PropertyGroup>
-    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0'">true</_FrameworkIncludesNullableAttributes>
-    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">true</_FrameworkIncludesNullableAttributes>
+    <_FrameworkIncludesNullableAttributes Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">true</_FrameworkIncludesNullableAttributes>
     <_FrameworkIncludesNullableAttributes Condition="'$(_FrameworkIncludesNullableAttributes)' == ''">false</_FrameworkIncludesNullableAttributes>
 
     <GenerateNullableAttributes Condition="'$(GenerateNullableAttributes)' == '' AND '$(_FrameworkIncludesNullableAttributes)' != 'true'">true</GenerateNullableAttributes>
@@ -28,14 +28,14 @@
     </ResolveAssemblyReferencesDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '3.0'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveLockFileReferences</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveLockFileReferences</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
 
   <PropertyGroup Condition="
-                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0')
-                 OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1')">
+                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0')))
+                 OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1')))">
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveTargetingPackAssets</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
@@ -97,7 +97,7 @@
           Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           DependsOnTargets="$(RestoreTargetFrameworkDirectoryDependsOn)"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
       <_TargetFrameworkReferences Include="@(Reference)"
                                   Condition="
                                 '%(NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -153,18 +153,18 @@
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
       <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(ResolvedCompileFileDefinitionsToAdd.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.0'))">
       <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App'" />
       <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
@@ -210,7 +210,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
                                       AND ('%(Reference.NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -266,19 +266,19 @@
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.1'))">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '2.0'))">
       <UnannotatedReferenceAssembly Include="@(ResolvedCompileFileDefinitionsToAdd->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(ResolvedCompileFileDefinitionsToAdd.FileName)%(ResolvedCompileFileDefinitionsToAdd.Extension)')"
                                     OriginalReference="%(ResolvedCompileFileDefinitionsToAdd.Identity)" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.0'">
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '2.0'))">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="('%(Reference.FrameworkReferenceName)' == 'Microsoft.NETCore.App' OR '%(Reference.PackageName)' == 'Microsoft.NETCore.App') AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)" />

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -28,7 +28,9 @@
     <AddStandardAssembliesForAnnotationDependsOn>ResolveLockFileReferences</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0'">
+  <PropertyGroup Condition="
+                 ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '3.0')
+                 OR ('$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1')">
     <RestoreTargetFrameworkDirectoryDependsOn>ResolveTargetingPackAssets</RestoreTargetFrameworkDirectoryDependsOn>
     <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
@@ -90,8 +92,7 @@
           Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp'"
           DependsOnTargets="$(RestoreTargetFrameworkDirectoryDependsOn)"
           BeforeTargets="ResolveAvailableReferenceAssemblies">
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
-      <!-- .NET Standard 1.x -->
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <_TargetFrameworkReferences Include="@(Reference)"
                                   Condition="
                                 '%(NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -142,9 +143,15 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
-      <!-- .NET Standard 2+ -->
+      <!-- .NET Standard 2.0 -->
       <_NuGetPackageFoldersItems Include="$(NuGetPackageFolders)" />
       <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_NuGetPackageFoldersItems.Identity)', 'netstandard.library', '$(NETStandardLibraryPackageVersion)', 'build', 'netstandard2.0', 'ref'))" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
+      <_TargetFrameworkReferences Include="@(Reference)" Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library'" />
+      <_TargetFrameworkNuGetPackageFoldersNoSlash Include="$([System.IO.Path]::GetDirectoryName('%(_TargetFrameworkReferences.Identity)'))" />
+      <_TargetFrameworkNuGetPackageFolders Include="$([MSBuild]::NormalizeDirectory('%(_TargetFrameworkNuGetPackageFoldersNoSlash.Identity)'))" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
@@ -193,8 +200,7 @@
                                         OR '%(Reference.Identity)' == 'System.Xml.Linq')" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' == ''">
-      <!-- .NET Standard 1.x -->
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '2.0'">
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')
                                       AND ('%(Reference.NuGetPackageId)' == 'Microsoft.Win32.Primitives'
@@ -245,11 +251,17 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(NETStandardLibraryPackageVersion)' != ''">
-      <!-- .NET Standard 2+ -->
+      <!-- .NET Standard 2.0 -->
       <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
                                     Condition="'%(Reference.NuGetPackageId)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
                                     OriginalReference="%(Reference.Identity)"
                                     IsNetStandard="True" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFrameworkVersion.Substring(1))' &gt;= '2.1'">
+      <UnannotatedReferenceAssembly Include="@(Reference->'%(FileName)')"
+                                    Condition="'%(Reference.FrameworkReferenceName)' == 'NETStandard.Library' AND Exists('$(AnnotatedReferenceAssemblyDirectory)%(Reference.FileName)%(Reference.Extension)')"
+                                    OriginalReference="%(Reference.Identity)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,19 @@ test_script:
 - git clean -dxf tests
 - msbuild /restore tests/SingleTFM /p:TestFramework=netstandard2.0 /warnaserror /v:m
 - git clean -dxf tests
+- msbuild /restore tests/SingleTFM /p:TestFramework=netstandard2.1 /warnaserror /v:m
+- git clean -dxf tests
 - msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp1.0 /p:DisableImplicitNuGetFallbackFolder=true /warnaserror /v:m
 - git clean -dxf tests
 - msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp1.1 /p:DisableImplicitNuGetFallbackFolder=true /warnaserror /v:m
+- git clean -dxf tests
+- msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp2.0 /warnaserror /v:m
+- git clean -dxf tests
+- msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp2.1 /warnaserror /v:m
+- git clean -dxf tests
+- msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp3.0 /warnaserror /v:m
+- git clean -dxf tests
+- msbuild /restore tests/SingleTFM /p:TestFramework=netcoreapp3.1 /warnaserror /v:m
 
 - git clean -dxf tests
 - dotnet msbuild -restore tests/MultiTFM -warnaserror -v:m
@@ -43,9 +53,24 @@ test_script:
 - dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netstandard2.0 -warnaserror -v:m
 - taskkill /im dotnet.exe /f
 - git clean -dxf tests
+- dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netstandard2.1 -warnaserror -v:m
+- taskkill /im dotnet.exe /f
+- git clean -dxf tests
 - dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp1.0 -p:DisableImplicitNuGetFallbackFolder=true -warnaserror -v:m
 - taskkill /im dotnet.exe /f
 - git clean -dxf tests
 - dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp1.1 -p:DisableImplicitNuGetFallbackFolder=true -warnaserror -v:m
+- taskkill /im dotnet.exe /f
+- git clean -dxf tests
+- dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp2.0 -warnaserror -v:m
+- taskkill /im dotnet.exe /f
+- git clean -dxf tests
+- dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp2.1 -warnaserror -v:m
+- taskkill /im dotnet.exe /f
+- git clean -dxf tests
+- dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp3.0 -warnaserror -v:m
+- taskkill /im dotnet.exe /f
+- git clean -dxf tests
+- dotnet msbuild -restore tests/SingleTFM -p:TestFramework=netcoreapp3.1 -warnaserror -v:m
 artifacts:
 - path: 'TunnelVisionLabs.ReferenceAssemblyAnnotator\**\*.nupkg'

--- a/tests/MultiTFM/MultiTFM.csproj
+++ b/tests/MultiTFM/MultiTFM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net48;netstandard1.6;netstandard2.0;netcoreapp1.0;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net35;net48;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <AnnotatedReferenceAssemblyVersion>3.0.0</AnnotatedReferenceAssemblyVersion>


### PR DESCRIPTION
Fixes #38
Fixes #50
Supersedes #49

I verified that source attributes are added by default when appropriate and rewritten assemblies are being used by CscTask for `<TargetFrameworks>net35;net48;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>`.