### PR TITLE
Fix AvailableUnannotatedReferenceAssembly items

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -62,9 +62,12 @@
           DependsOnTargets="GetReferenceAssemblyPaths">
     <ItemGroup>
       <AvailableUnannotatedReferenceAssemblyDirectory Include="$(TargetFrameworkDirectory)" />
-      <!-- Use an intermediate item group so AvailableUnannotatedReferenceAssembly contains the expanded glob -->
-      <_AvailableUnannotatedReferenceAssembly Include="@(AvailableUnannotatedReferenceAssemblyDirectory->'%(Identity)*.dll')" />
-      <AvailableUnannotatedReferenceAssembly Include="@(_AvailableUnannotatedReferenceAssemblyDirectory)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_AvailableUnannotatedReferenceAssemblyGlobs>@(AvailableUnannotatedReferenceAssemblyDirectory->'%(Identity)*.dll')</_AvailableUnannotatedReferenceAssemblyGlobs>
+    </PropertyGroup>
+    <ItemGroup>
+      <AvailableUnannotatedReferenceAssembly Include="$(_AvailableUnannotatedReferenceAssemblyGlobs)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
No AvailableUnannotatedReferenceAssembly items were being created. There may be a better approach, but the existing approach doesn't work as of MSBuild 16.4.

The only place these items are used is the AnnotateReferenceAssemblies target input listing. Seems important. 

Before (no AvailableUnannotatedReferenceAssembly):
![image](https://user-images.githubusercontent.com/8040367/71637305-7f4a6380-2c0d-11ea-829a-e908d20609c3.png)

After:

![image](https://user-images.githubusercontent.com/8040367/71637295-5924c380-2c0d-11ea-8c41-f12cdbea8b0c.png)
