### PR TITLE
Add autodetection of PackageDownload version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,39 +38,32 @@ IL weaver for adding nullability annotations to .NET Framework, .NET Standard, a
 
 ```xml
 <PropertyGroup>
-  <!-- Specifies the version of this rewriter to use. -->
-  <TunnelVisionLabsReferenceAssemblyAnnotatorVersion>1.0.0-alpha.138</TunnelVisionLabsReferenceAssemblyAnnotatorVersion>
-
-  <!-- Specifies the version of Microsoft.NETCore.App.Ref to obtain nullability information from. -->
-  <AnnotatedReferenceAssemblyVersion>3.1.0</AnnotatedReferenceAssemblyVersion>
-
   <!-- Includes the nullable attributes from dotnet/coreclr as source code with 'internal' accessibility. Set this to
        false if the attributes are included from another source and/or are not needed. -->
   <GenerateNullableAttributes>true</GenerateNullableAttributes>
 </PropertyGroup>
 
 <ItemGroup>
-  <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="$(TunnelVisionLabsReferenceAssemblyAnnotatorVersion)" PrivateAssets="all" />
-  <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+  <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.138" PrivateAssets="all" />
+
+  <!-- Specifies the version of Microsoft.NETCore.App.Ref to obtain nullability information from. -->
+  <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
 </ItemGroup>
 ```
 
 Minimal:
 
 ```xml
-<PropertyGroup>
-  <AnnotatedReferenceAssemblyVersion>3.1.0</AnnotatedReferenceAssemblyVersion>
-</PropertyGroup>
 <ItemGroup>
   <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.138" PrivateAssets="all" />
-  <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+  <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
 </ItemGroup>
 ```
 
 ### Configuration reference
 
 * MSBuild properties
-    * `<AnnotatedReferenceAssemblyVersion>`: Specifies the version of Microsoft.NETCore.App.Ref to obtain nullability information from. There is no default value, so this must be specified by the user.
+    * `<AnnotatedReferenceAssemblyVersion>`: Specifies the version of Microsoft.NETCore.App.Ref to obtain nullability information from. This is required if there are multiple PackageDownload versions of Microsoft.NETCore.App.Ref.
     * `<GenerateNullableAttributes>`: Set to `True` to include definitions of nullability attributes in the build; otherwise, `False` to exclude the definitions. The default value is `True`.
 * MSBuild items
     * `<UnannotatedReferenceAssembly>`: Specifies reference assemblies to annotate. This is only required for assemblies that are not automatically annotated by this package.

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/TunnelVisionLabs.ReferenceAssemblyAnnotator.targets
@@ -42,7 +42,32 @@
     <AddStandardAssembliesForAnnotationDependsOn>ResolveTargetingPackAssets</AddStandardAssembliesForAnnotationDependsOn>
   </PropertyGroup>
 
-  <Target Name="ResolveAnnotatedReferenceAssemblies">
+  <Target Name="DetermineAnnotationPackageDownloadVersion">          
+    <ItemGroup>
+      <_CandidatePackageDownloadVersion Include="@(PackageDownload->'%(Version)'->Distinct())" Condition="'%(PackageDownload.Identity)' == 'Microsoft.NETCore.App.Ref'" />
+    </ItemGroup>
+
+    <Error Condition="@(_CandidatePackageDownloadVersion->Count()) &lt; 1" 
+           Text="Add a 'PackageDownload' project item to include Microsoft.NETCore.App.Ref at the desired version to obtain nullability information from."
+           Code="RA0000" />
+
+    <Error Condition="'$(AnnotatedReferenceAssemblyVersion)' == '' AND @(_CandidatePackageDownloadVersion->Count()) &gt; 1"
+           Text="There is more than one PackageDownload of Microsoft.NETCore.App.Ref. Set the 'AnnotatedReferenceAssemblyVersion' build property to the version to obtain nullability information from."
+           Code="RA0001" />
+
+    <Error Condition="'$(AnnotatedReferenceAssemblyVersion)' != '' 
+                      AND @(_CandidatePackageDownloadVersion->WithMetadataValue('Identity', '[$(AnnotatedReferenceAssemblyVersion)]')->Count()) &lt; 1"
+           Text="There is no PackageDownload of Microsoft.NETCore.App.Ref with the version specified by the 'AnnotatedReferenceAssemblyVersion' build property."
+           Code="RA0002" />
+
+    <PropertyGroup Condition="'$(AnnotatedReferenceAssemblyVersion)' == ''">
+      <_AnnotatedReferenceAssemblyVersionWithSquareBrackets>@(_CandidatePackageDownloadVersion)</_AnnotatedReferenceAssemblyVersionWithSquareBrackets>
+      <AnnotatedReferenceAssemblyVersion>$(_AnnotatedReferenceAssemblyVersionWithSquareBrackets.TrimStart('[').TrimEnd(']'))</AnnotatedReferenceAssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ResolveAnnotatedReferenceAssemblies"
+          DependsOnTargets="DetermineAnnotationPackageDownloadVersion">
     <ItemGroup Condition="'$(AnnotatedReferenceAssemblyDirectory)' == ''">
       <_AnnotatedReferenceAssemblyDirectoryContents Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\$(AnnotatedReferenceAssemblyVersion)\ref\*\*.dll" />
       <_AnnotatedReferenceAssemblyDirectoryItem Include="@(_AnnotatedReferenceAssemblyDirectoryContents->'%(RelativeDir)')" />
@@ -83,8 +108,6 @@
           DependsOnTargets="$(AnnotateReferenceAssembliesDependsOn)"
           Inputs="@(AvailableUnannotatedReferenceAssembly);@(AnnotatedReferenceAssembly)"
           Outputs="@(UnannotatedReferenceAssembly->'%(OutputAssembly)')">
-
-    <Error Condition="'$(AnnotatedReferenceAssemblyVersion)' == ''" Text="The 'AnnotatedReferenceAssemblyVersion' build property was not set." Code="RA0000" />
 
     <AnnotatorBuildTask
       UnannotatedReferenceAssembly="%(UnannotatedReferenceAssembly.Identity)"

--- a/tests/MultiTFM/MultiTFM.csproj
+++ b/tests/MultiTFM/MultiTFM.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net35;net48;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <AnnotatedReferenceAssemblyVersion>3.0.0</AnnotatedReferenceAssemblyVersion>
     <NoWarn>RA1000</NoWarn>
   </PropertyGroup>
 
@@ -26,7 +25,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' != 'net35'" Include="System.Data.SqlClient" Version="4.8.0" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.*" PrivateAssets="all" />
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.0.0]" />
   </ItemGroup>
 
 </Project>

--- a/tests/RefVersion3.1.0/RefVersion3.1.0.csproj
+++ b/tests/RefVersion3.1.0/RefVersion3.1.0.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net35;net48;netstandard1.6;netstandard2.0;netstandard2.1;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <AnnotatedReferenceAssemblyVersion>3.1.0</AnnotatedReferenceAssemblyVersion>
     <NoWarn>RA1000</NoWarn>
   </PropertyGroup>
 
@@ -26,7 +25,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' != 'net35'" Include="System.Data.SqlClient" Version="4.8.0" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.*" PrivateAssets="all" />
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
   </ItemGroup>
 
 </Project>

--- a/tests/SingleTFM/SingleTFM.csproj
+++ b/tests/SingleTFM/SingleTFM.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(TestFramework)</TargetFramework>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
-    <AnnotatedReferenceAssemblyVersion>3.0.0</AnnotatedReferenceAssemblyVersion>
     <NoWarn>RA1000</NoWarn>
   </PropertyGroup>
 
@@ -21,7 +20,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' != 'net35'" Include="System.Data.SqlClient" Version="4.8.0" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.*" PrivateAssets="all" />
-    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.0.0]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Next best while sticking with PackageDownload as the means of obtaining the package, since https://github.com/tunnelvisionlabs/ReferenceAssemblyAnnotator/issues/70 is not technically feasible.