### PR TITLE
Skip copying documentation file when target already exists

### DIFF
--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -104,7 +104,14 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
             string targetDocumentation = Path.ChangeExtension(outputAssembly, ".xml");
             if (File.Exists(sourceDocumentation))
             {
-                File.Copy(sourceDocumentation, targetDocumentation);
+                try
+                {
+                    File.Copy(sourceDocumentation, targetDocumentation);
+                }
+                catch (IOException ex) when ((WindowsErrorCode)ex.HResult == WindowsErrorCode.FileExists)
+                {
+                }
+
                 GeneratedDocumentationFiles = new[] { new TaskItem(targetDocumentation) };
             }
             else

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/AnnotatorBuildTask.cs
@@ -102,7 +102,7 @@ namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
 
             string sourceDocumentation = Path.ChangeExtension(unannotatedReferenceAssembly, ".xml");
             string targetDocumentation = Path.ChangeExtension(outputAssembly, ".xml");
-            if (File.Exists(sourceDocumentation))
+            if (File.Exists(sourceDocumentation) && !File.Exists(targetDocumentation))
             {
                 try
                 {

--- a/TunnelVisionLabs.ReferenceAssemblyAnnotator/WindowsErrorCode.cs
+++ b/TunnelVisionLabs.ReferenceAssemblyAnnotator/WindowsErrorCode.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace TunnelVisionLabs.ReferenceAssemblyAnnotator
+{
+    internal enum WindowsErrorCode : ushort
+    {
+        /// <summary>
+        /// https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-#error_file_exists
+        /// </summary>
+        FileExists = 80,
+    }
+}


### PR DESCRIPTION
Fixes #74. Verified that `File.Copy` throws an exception whose `(ushort)ex.HResult` is `80` due to the target being an existing file.

⚠ This may not be the right (or only) fix needed to close the issue. See issue discussion.